### PR TITLE
Fix cell separator insets

### DIFF
--- a/Gistan/View/GistItemTableViewCell.swift
+++ b/Gistan/View/GistItemTableViewCell.swift
@@ -19,6 +19,11 @@ class GistItemTableViewCell: UITableViewCell {
         super.awakeFromNib()
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        separatorInset.left = titleLabel.convert(titleLabel.bounds.origin, to: self).x
+    }
+
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
     }


### PR DESCRIPTION
Cell's separator insets should start from label origin like this:


![1](https://user-images.githubusercontent.com/1255062/32223152-98b64102-be7f-11e7-9918-4c25d59cc833.png)


## Before

. | . | .
--- | --- | --- 
![1](https://user-images.githubusercontent.com/1255062/32223161-a5239c00-be7f-11e7-9ae3-557c68cd723a.png) | ![2](https://user-images.githubusercontent.com/1255062/32223162-a54646e2-be7f-11e7-9866-3a06b277b499.png) | ![simulator screen shot - iphone x - 2017-10-31 at 21 11 22](https://user-images.githubusercontent.com/1255062/32223281-0f8f3176-be80-11e7-9f97-ba479d31be9d.png)


## After

. | . | .
--- | --- | ---
![simulator screen shot - iphone x - 2017-10-31 at 21 12 01](https://user-images.githubusercontent.com/1255062/32223304-25537e9a-be80-11e7-9a15-86ed0f5e11fa.png) | ![6](https://user-images.githubusercontent.com/1255062/32223195-bfcd573a-be7f-11e7-896f-a50f6cc15d97.png) | ![simulator screen shot - iphone x - 2017-10-31 at 21 10 08](https://user-images.githubusercontent.com/1255062/32223241-eeeeebbe-be7f-11e7-8eef-5358216dfcbd.png)

 