### PR TITLE
Add Material icons license

### DIFF
--- a/license_plist.yml
+++ b/license_plist.yml
@@ -3,3 +3,7 @@ github:
     name: LicensePlist
   - owner: mzp
     name: OctoEye
+  - owner: google
+    name: material-design-icons
+rename:
+  material-design-icons: Material icons


### PR DESCRIPTION
[Material icons - Material Design](https://material.io/icons/)
> The icons are available under the Apache License Version 2.0. We'd love attribution in your app's "about" screen, but it's not required. The only thing we ask is that you not re-sell these icons.

Even though `not required`, it is better to list the license.

list | detail
--- | ---
![simulator screen shot - iphone 8 - 2017-11-01 at 09 59 49](https://user-images.githubusercontent.com/1255062/32255478-873f1612-beeb-11e7-9d5e-2a936fd5fae0.png) | ![simulator screen shot - iphone 8 - 2017-11-01 at 09 59 55](https://user-images.githubusercontent.com/1255062/32255480-89dbc622-beeb-11e7-8e27-662db8b47e16.png)



On iPhone X, the license page maybe blank.
This is LicensePlist's problem, and I'm trying to fix now.
[Can't show license pages under some condition(long license body?) at iPhone X simulator. · Issue #79 · mono0926/LicensePlist](https://github.com/mono0926/LicensePlist/issues/79)